### PR TITLE
Ignore local dir walk errors if files were found

### DIFF
--- a/clients/localdir/client.go
+++ b/clients/localdir/client.go
@@ -106,8 +106,8 @@ func listFiles(clientPath string) ([]string, error) {
 
 		return nil
 	})
-	if err != nil {
-		return nil, fmt.Errorf("error walking the path %q: %w", clientPath, err)
+	if err != nil { // If any files were found, then return them, and let the caller choose to process it
+		return files, fmt.Errorf("error walking the path %q: %w", clientPath, err)
 	}
 
 	return files, nil
@@ -118,7 +118,8 @@ func applyPredicate(
 	errFiles error,
 	predicate func(string) (bool, error),
 ) ([]string, error) {
-	if errFiles != nil {
+	// If there was an error and no client files were found, then return here; else process client files at best effort
+	if errFiles != nil && len(clientFiles) == 0 {
 		return nil, errFiles
 	}
 


### PR DESCRIPTION
#### What kind of change does this PR introduce?
Errors generated while walking the local directory will be ignored if at least one file was found so that checks can still be run.

- [ ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
If any error is generated while walking the local directory, then checks do not run

#### What is the new behavior (if this is a feature change)?**
If any error is generated while walking the local directory, then checks will still run on any files that were found.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
