### PR TITLE
Enable Binary artifacts check for local repos

### DIFF
--- a/checks/binary_artifact.go
+++ b/checks/binary_artifact.go
@@ -27,6 +27,7 @@ const CheckBinaryArtifacts string = "Binary-Artifacts"
 //nolint
 func init() {
 	supportedRequestTypes := []checker.RequestType{
+		checker.FileBased,
 		checker.CommitBased,
 	}
 	if err := registerCheck(CheckBinaryArtifacts, BinaryArtifacts, supportedRequestTypes); err != nil {

--- a/pkg/scorecard.go
+++ b/pkg/scorecard.go
@@ -95,7 +95,7 @@ func RunScorecards(ctx context.Context,
 	defer repoClient.Close()
 
 	commitSHA, err := getRepoCommitHash(repoClient)
-	if err != nil || commitSHA == "" {
+	if err != nil {
 		return ScorecardResult{}, err
 	}
 	versionInfo := version.GetVersionInfo()


### PR DESCRIPTION
#### What kind of change does this PR introduce?
Enable Binary artifacts check for local repositories that was disabled in the PR #2039 and revert the change done for empty repository handling in the PR #2207

(Is it a bug fix, feature, docs update, something else?)

- [ ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Binary artifacts check is disabled for local repositories and none of the scorecard checks are running for a locally cloned android repository, as it is detecting it as an empty repository
#### What is the new behavior (if this is a feature change)?**
Binary artifacts check is enabled for local repositories and scorecard checks will run for a locally cloned android repository
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
