### PR TITLE
Handle Unsupported Dependency Update tool check

### DIFF
--- a/checks/raw/dependency_update_tool.go
+++ b/checks/raw/dependency_update_tool.go
@@ -41,7 +41,12 @@ func DependencyUpdateTool(c clients.RepoClient) (checker.DependencyUpdateToolDat
 
 	commits, err := c.SearchCommits(clients.SearchCommitsOptions{Author: "dependabot[bot]"})
 	if err != nil {
-		return checker.DependencyUpdateToolData{}, fmt.Errorf("%w", err)
+		// Do not fail if client returns an unsupported error
+		if strings.Contains(err.Error(), clients.ErrUnsupportedFeature.Error()) {
+			return checker.DependencyUpdateToolData{Tools: tools}, nil
+		} else {
+			return checker.DependencyUpdateToolData{}, fmt.Errorf("%w", err)
+		}
 	}
 
 	for i := range commits {


### PR DESCRIPTION
#### What kind of change does this PR introduce?
New functionality added as part of the PR #2125 is not supported for local repositories. When this code path is hit, it will check if it is an unsupported error and not fail the Dependency Update tool check. Fallback to existing behavior for any other type of errors

(Is it a bug fix, feature, docs update, something else?)

- [ ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
When unsupported code path is hit in Dependency Update tool, it generates an internal error and scorecard eventually exits with an error code of 1
#### What is the new behavior (if this is a feature change)?**
When unsupported code path is hit in Dependency Update tool, it will not generate an internal error and scorecard will exit with a zero error code. For any other type of errors, it will fall back to existing behavior
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
