### PR TITLE
Ignore shell parsing error in pinned dependencies check

### DIFF
--- a/checks/raw/pinned_dependencies.go
+++ b/checks/raw/pinned_dependencies.go
@@ -95,7 +95,11 @@ var validateShellScriptIsFreeOfInsecureDownloads fileparser.DoWhileTrueOnFileCon
 	}
 
 	if err := validateShellFile(pathfn, 0, 0, content, map[string]bool{}, pdata); err != nil {
-		return false, nil
+		// Do not fail if client returns a shell parsing error.
+		// Parsing error may be generated due to commonly used and unsupported "((" ambiguity
+		if !strings.Contains(err.Error(), sce.ErrorShellParsing.Error()) {
+			return false, nil
+		}
 	}
 
 	return true, nil
@@ -163,7 +167,11 @@ var validateDockerfileInsecureDownloads fileparser.DoWhileTrueOnFileContent = fu
 		bytes = append(bytes, cmd...)
 		if err := validateShellFile(pathfn, uint(child.StartLine)-1, uint(child.EndLine)-1,
 			bytes, taintedFiles, pdata); err != nil {
-			return false, err
+			// Do not fail if client returns a shell parsing error.
+			// Parsing error may be generated due to commonly used and unsupported "((" ambiguity
+			if !strings.Contains(err.Error(), sce.ErrorShellParsing.Error()) {
+				return false, err
+			}
 		}
 	}
 


### PR DESCRIPTION
Ignore shell parsing error in pinned dependencies check that may come due to unsupported and commonly used "((" pattern in files

#### What kind of change does this PR introduce?

It is a bugfix change

#### What is the current behavior?
It generates an internal error and exit with a -1 error code when shell parsing error occurs as part of the pinned dependencies check

#### What is the new behavior (if this is a feature change)?**
It ignores a shell parsing error and continues with the rest of the checks
