### PR TITLE
🐛  Ignore unknown OS error pinned dependencies check

### DIFF
--- a/checks/raw/pinned_dependencies.go
+++ b/checks/raw/pinned_dependencies.go
@@ -391,7 +391,13 @@ var validateGitHubWorkflowIsFreeOfInsecureDownloads fileparser.DoWhileTrueOnFile
 			// https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsrun.
 			shell, err := fileparser.GetShellForStep(step, job)
 			if err != nil {
-				return false, err
+				// Issues might occur in getting a step's os from the workflow yaml
+				// Hence, skip to next iteration if error occurs
+				if !strings.Contains(err.Error(), "unable to determine OS for job:") {
+					return false, err
+				} else {
+					continue
+				}
 			}
 			// Skip unsupported shells. We don't support Windows shells or some Unix shells.
 			if !isSupportedShell(shell) {


### PR DESCRIPTION
Ignore unknown OS error that can be raised while parsing shell script in a job in pinned dependencies check

#### What kind of change does this PR introduce?
It is a bug fix change
(Is it a bug fix, feature, docs update, something else?)

- [ ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)
Yes

#### What is the current behavior?
It generates an internal error and exit with a -1 error code when unknown OS is found while looking for shell parsing jobs as part of the pinned dependencies check

#### What is the new behavior (if this is a feature change)?**
It ignores unknown OS found while parsing jobs with shell script in it and continues with the rest of the checks

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
