### PR TITLE
Update go.mod to import from scorecard in lineaje-labs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -205,3 +205,5 @@ replace (
 	// This replace is for https://github.com/advisories/GHSA-25xm-hr59-7c27
 	github.com/ulikunitz/xz => github.com/ulikunitz/xz v0.5.8
 )
+
+replace github.com/ossf/scorecard/v4 => github.com/lineaje-labs/scorecard/v4 lineaje-v4.11.0


### PR DESCRIPTION
Update go.mod to import from scorecard in lineaje-labs instead of ossf