### PR TITLE
Enable License check for local repos

### DIFF
--- a/checks/license.go
+++ b/checks/license.go
@@ -27,6 +27,7 @@ const CheckLicense = "License"
 //nolint:gochecknoinits
 func init() {
 	supportedRequestTypes := []checker.RequestType{
+		checker.FileBased,
 		checker.CommitBased,
 	}
 	if err := registerCheck(CheckLicense, License, supportedRequestTypes); err != nil {


### PR DESCRIPTION
Enable License check for local repositories that was disabled in the PR #2442

#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)
Bug fix

- [ ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
License check is disabled for local repositories

#### What is the new behavior (if this is a feature change)?**
License check is enabled for local repositories and scorecard checks will run for a locally cloned repository

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
