### PR TITLE
Skip .git folder when running on local folder

### DIFF
--- a/checks/fileparser/listing.go
+++ b/checks/fileparser/listing.go
@@ -53,6 +53,7 @@ func isTestdataFile(fullpath string) bool {
 	// testdata/ or /some/dir/testdata/some/other
 	return strings.HasPrefix(fullpath, "testdata/") ||
 		strings.Contains(fullpath, "/testdata/") ||
+		strings.HasPrefix(fullpath, ".git/") ||
 		strings.HasPrefix(fullpath, "src/test/") ||
 		strings.Contains(fullpath, "/src/test/")
 }


### PR DESCRIPTION
Skip .git folder when running on local folder as glob files in that folder can be as big as 3GB. This is the case with azure-core repository where scorecard was running out of memory when it read such large files

#### What kind of change does this PR introduce?
Bug fix

- [ ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
It reads  files from .git folder into memory. Repository like azure-core has files of size 3 GB which generates an OOM when run within an AWS ECS task.
#### What is the new behavior (if this is a feature change)?**
After this change, it will skip everything inside .git folder
- [ ] Tests for the changes have been added (for bug fixes/features)
No
#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
