### PR TITLE
Update go.mod to import scorecard v5.4.0 from lineaje-labs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -315,4 +315,5 @@ replace (
 	// pinned until https://github.com/containerd/containerd/issues/12493 is resolved and containerd/containerd handles the new runtime spec.
 	github.com/containerd/cgroups/v3 => github.com/containerd/cgroups/v3 v3.1.2
 	github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.2.1
+	github.com/ossf/scorecard/v5 => github.com/lineaje-labs/scorecard/v5 v5.4.0-1-lineaje
 )

--- a/go.sum
+++ b/go.sum
@@ -704,6 +704,8 @@ github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/lineaje-labs/scorecard/v5 v5.4.0-1-lineaje h1:uO67xXiiIVYQKyj6c8oQqPMhxqtn1fQ45yTfwWba/Mw=
+github.com/lineaje-labs/scorecard/v5 v5.4.0-1-lineaje/go.mod h1:aO46AmmlxIqSNLAukAH63CPyHBAg+RePCcVS5Ji54P0=
 github.com/lunixbochs/struc v0.0.0-20200707160740-784aaebc1d40 h1:EnfXoSqDfSNJv0VBNqY/88RNnhSGYkrHaO0mmFGbVsc=
 github.com/lunixbochs/struc v0.0.0-20200707160740-784aaebc1d40/go.mod h1:vy1vK6wD6j7xX6O6hXe621WabdtNkou2h7uRtTfRMyg=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -828,8 +830,6 @@ github.com/opencontainers/selinux v1.13.1 h1:A8nNeceYngH9Ow++M+VVEwJVpdFmrlxsN22
 github.com/opencontainers/selinux v1.13.1/go.mod h1:S10WXZ/osk2kWOYKy1x2f/eXF5ZHJoUs8UU/2caNRbg=
 github.com/ossf/osv-schema/bindings/go v0.0.0-20251012234424-434020c6442f h1:0AlxQEA7JATli/nATcQ66fAASlokay8Qpcdjhqxd1gU=
 github.com/ossf/osv-schema/bindings/go v0.0.0-20251012234424-434020c6442f/go.mod h1:/ypmJBpoMvgNp4g93snzyYoyIPmZfLdSiGn/Vq07Dfo=
-github.com/ossf/scorecard/v5 v5.4.0 h1:C22K60yeZBOjdrjosYGRhsr4a6Ne7q5DlbMQ8CfHBbU=
-github.com/ossf/scorecard/v5 v5.4.0/go.mod h1:eyelXNh0+QdHeYkHpQat+hzDVds8OhZhnyWy33rcCuM=
 github.com/otiai10/copy v1.14.1 h1:5/7E6qsUMBaH5AnQ0sSLzzTg1oTECmcCmT6lvF45Na8=
 github.com/otiai10/copy v1.14.1/go.mod h1:oQwrEDDOci3IM8dJF0d8+jnbfPDllW6vUjNc3DoZm9I=
 github.com/otiai10/mint v1.6.3 h1:87qsV/aw1F5as1eH1zS/yqHY85ANKVMgkDrf9rcxbQs=


### PR DESCRIPTION
Update go.mod to import scorecard v5.4.0 from lineaje-labs