### PR TITLE
Update go.mod to import scorecard v5.4.0 from lineaje-labs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -133,7 +133,6 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.36.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.0 // indirect
 	github.com/erikvarga/go-rpmdb v0.0.0-20250523120114-a15a62cd4593 // indirect
-	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-errors/errors v1.0.2 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.3 // indirect
@@ -327,6 +326,6 @@ replace (
 	// pinned until https://github.com/containerd/containerd/issues/12493 is resolved and containerd/containerd handles the new runtime spec.
 	github.com/containerd/cgroups/v3 => github.com/containerd/cgroups/v3 v3.1.2
 	github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.2.1
-	github.com/ossf/scorecard/v5 => github.com/lineaje-labs/scorecard/v5 v5.4.0-1-lineaje
+	github.com/ossf/scorecard/v5 => github.com/lineaje-labs/scorecard/v5 v5.4.0-2-lineaje
 	google.golang.org/grpc => google.golang.org/grpc v1.79.3
 )

--- a/go.sum
+++ b/go.sum
@@ -3637,8 +3637,8 @@ github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
-github.com/lineaje-labs/scorecard/v5 v5.4.0-1-lineaje h1:uO67xXiiIVYQKyj6c8oQqPMhxqtn1fQ45yTfwWba/Mw=
-github.com/lineaje-labs/scorecard/v5 v5.4.0-1-lineaje/go.mod h1:aO46AmmlxIqSNLAukAH63CPyHBAg+RePCcVS5Ji54P0=
+github.com/lineaje-labs/scorecard/v5 v5.4.0-2-lineaje h1:GXCQVVolVECZYy2yFcM3h/T6mFa03t2AXKRsdvyxKEE=
+github.com/lineaje-labs/scorecard/v5 v5.4.0-2-lineaje/go.mod h1:sUHBo37bjI0EetOHXlxN30FPKccinHGZIsUr+5LDpsc=
 github.com/lunixbochs/struc v0.0.0-20200707160740-784aaebc1d40 h1:EnfXoSqDfSNJv0VBNqY/88RNnhSGYkrHaO0mmFGbVsc=
 github.com/lunixbochs/struc v0.0.0-20200707160740-784aaebc1d40/go.mod h1:vy1vK6wD6j7xX6O6hXe621WabdtNkou2h7uRtTfRMyg=
 github.com/lyft/protoc-gen-star v0.6.0/go.mod h1:TGAoBVkt8w7MPG72TrKIu85MIdXwDuzJYeZuUPFPNwA=


### PR DESCRIPTION
Update go.mod to import scorecard v5.4.0 from lineaje-labs