### PR TITLE
Update go.mod to import scorecard v5.4.0 from lineaje-labs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -327,7 +327,7 @@ replace (
 	github.com/containerd/cgroups/v3 => github.com/containerd/cgroups/v3 v3.1.2
 	github.com/go-jose/go-jose/v4 => github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/opencontainers/runtime-spec => github.com/opencontainers/runtime-spec v1.2.1
-	github.com/ossf/scorecard/v5 => github.com/lineaje-labs/scorecard/v5 v5.4.0-3-lineaje
+	github.com/ossf/scorecard/v5 => github.com/lineaje-labs/scorecard/v5 v5.4.0-4-lineaje
 	go.opentelemetry.io/otel/sdk => go.opentelemetry.io/otel/sdk v1.43.0
 	google.golang.org/grpc => google.golang.org/grpc v1.79.3
 )

--- a/go.sum
+++ b/go.sum
@@ -3634,8 +3634,8 @@ github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
-github.com/lineaje-labs/scorecard/v5 v5.4.0-3-lineaje h1:l7cVNgZUb+HZryNaa3LvKKR4a0YQbuvZZsPYMHP6ouk=
-github.com/lineaje-labs/scorecard/v5 v5.4.0-3-lineaje/go.mod h1:yVfJBHpMR1NCQchCPnKKCA8SXYv33P626MMk2XAPKIA=
+github.com/lineaje-labs/scorecard/v5 v5.4.0-4-lineaje h1:CZ7C+fIVS3BeiaPyoyFSulL/hzMyGB0TCRGz0oNWTK8=
+github.com/lineaje-labs/scorecard/v5 v5.4.0-4-lineaje/go.mod h1:57GkPsuMY+R+czoFWjnHtnyyNu8R5+tEV+x1DCS6nVU=
 github.com/lunixbochs/struc v0.0.0-20200707160740-784aaebc1d40 h1:EnfXoSqDfSNJv0VBNqY/88RNnhSGYkrHaO0mmFGbVsc=
 github.com/lunixbochs/struc v0.0.0-20200707160740-784aaebc1d40/go.mod h1:vy1vK6wD6j7xX6O6hXe621WabdtNkou2h7uRtTfRMyg=
 github.com/lyft/protoc-gen-star v0.6.0/go.mod h1:TGAoBVkt8w7MPG72TrKIu85MIdXwDuzJYeZuUPFPNwA=


### PR DESCRIPTION
Update go.mod to import scorecard v5.4.0 from lineaje-labs